### PR TITLE
Add CRITICALCSS_CONFIG_FILE environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ There are some environment variables that can be used while generating the criti
 
 ##### Available environment variables
 - DOMAIN: When domain is set, this will be used to render criticalcss for.
+- CRITICALCSS_CONFIG_FILE: You can alter the criticalcss configuration file that will be used. Can be useful when deploying to more than one environment or to support multiple themes.
 
 ##### How to use environment variables
 ```sh

--- a/generate.js
+++ b/generate.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
+const criticalcssConfigFile = process.env.CRITICALCSS_CONFIG_FILE || 'criticalcss.config';
+const { config, pages } = require('../../' + criticalcssConfigFile);
 const baseConfig = require('./config.default.js');
-const { config, pages } = require('../../criticalcss.config');
 const critical = require('critical');
 const { getClosestHeight } = require('./helpers');
 


### PR DESCRIPTION
Fixes #1 , where support for using another configuration file through an env variable was lost. Using this configuration file through env makes it possible to target another domain and other pages on that domain. The first domain might have completely different pages.